### PR TITLE
fix: Fix zoom button and keyboard shortcut functionality

### DIFF
--- a/diagram_renderer/renderers/templates/unified.html
+++ b/diagram_renderer/renderers/templates/unified.html
@@ -395,6 +395,14 @@
         <div class="bottom-controls">
             <div class="control-group">
                 <div class="zoom-controls">
+                    <button class="control-btn" onclick="zoomIn(); this.blur();" title="Zoom In">
+                        +
+                        <div class="tooltip">Zoom In</div>
+                    </button>
+                    <button class="control-btn" onclick="zoomOut(); this.blur();" title="Zoom Out">
+                        −
+                        <div class="tooltip">Zoom Out</div>
+                    </button>
                     <button class="control-btn" onclick="resetView(); this.blur();" title="Reset View">
                         ○
                         <div class="tooltip">Reset View</div>
@@ -445,6 +453,18 @@
             if (panzoomInstance) {
                 panzoomInstance.moveTo(0, 0);
                 panzoomInstance.zoomAbs(0, 0, 1);
+            }
+        }
+
+        function zoomIn() {
+            if (panzoomInstance) {
+                panzoomInstance.smoothZoom(0, 0, 1.2);
+            }
+        }
+
+        function zoomOut() {
+            if (panzoomInstance) {
+                panzoomInstance.smoothZoom(0, 0, 1/1.2);
             }
         }
 
@@ -579,17 +599,12 @@
                 case '+':
                 case '=':
                     e.preventDefault();
-                    if (panzoomInstance) {
-                        const transform = panzoomInstance.getTransform();
-                        panzoomInstance.zoomTo(transform.x, transform.y, transform.scale * 1.2);
-                    }
+                    zoomIn();
                     break;
                 case '-':
+                case '_':
                     e.preventDefault();
-                    if (panzoomInstance) {
-                        const transform = panzoomInstance.getTransform();
-                        panzoomInstance.zoomTo(transform.x, transform.y, transform.scale / 1.2);
-                    }
+                    zoomOut();
                     break;
                 case '0':
                     e.preventDefault();


### PR DESCRIPTION
## Summary
Fixes non-functional zoom in/out buttons and keyboard shortcuts in the diagram renderer. Mouse wheel zoom was working correctly, but the zoom control buttons and keyboard shortcuts (+/-) were not responding.

## Changes Made
- **Added missing zoom buttons**: Zoom in (+) and zoom out (−) buttons were missing from the unified HTML template
- **Fixed JavaScript zoom functions**: Updated zoom functions to use correct panzoom API (`smoothZoom`) instead of broken `zoomTo` calls  
- **Fixed keyboard shortcuts**: Updated keyboard event handlers to properly call zoom functions

## Problem Analysis
```mermaid
flowchart TD
    A[User clicks zoom button] --> B{JavaScript function called?}
    B -->|Yes| C{Panzoom API call correct?}
    B -->|No| D[❌ Button missing onclick handler]
    C -->|Yes| E[✅ Zoom works]
    C -->|No| F[❌ Wrong API method used]
    
    G[User presses +/- key] --> H{Keyboard event caught?}
    H -->|Yes| I{Correct zoom function called?}
    H -->|No| J[❌ Event listener issues]
    I -->|Yes| E
    I -->|No| K[❌ Direct API calls failing]
    
    style D fill:#ffcccb
    style F fill:#ffcccb
    style J fill:#ffcccb
    style K fill:#ffcccb
    style E fill:#90ee90
```

## Solution Overview
```mermaid
flowchart TD
    A[Unified Template] --> B[Zoom Control Buttons]
    A --> C[JavaScript Functions]
    A --> D[Keyboard Event Handlers]
    
    B --> E["zoomIn() onclick"]
    B --> F["zoomOut() onclick"]
    
    C --> G["panzoomInstance.smoothZoom"]
    
    D --> H["+ key calls zoomIn()"]
    D --> I["- key calls zoomOut()"]
    
    G --> J[✅ Consistent Zoom Behavior]
    
    style J fill:#90ee90
    style G fill:#add8e6
```

## Testing Results
- ✅ Zoom in button now works correctly
- ✅ Zoom out button now works correctly  
- ✅ Keyboard shortcuts (+/-) now work correctly
- ✅ Mouse wheel zoom continues to work as before
- ✅ Reset view and fullscreen buttons unaffected
- ✅ All pre-commit hooks pass (formatting, linting, tests)

## Technical Details
The issue was multi-faceted:
1. **Missing HTML elements**: The zoom in/out buttons were not present in the unified template
2. **Incorrect API usage**: Previous code used `panzoomInstance.zoomTo()` which doesn't work as expected
3. **Keyboard event handling**: Direct panzoom calls in keyboard handlers instead of using the zoom functions

**Fixed by**:
- Adding proper zoom button HTML elements with onclick handlers
- Implementing `zoomIn()` and `zoomOut()` functions using `panzoomInstance.smoothZoom(0, 0, scale)`
- Updating keyboard shortcuts to call the zoom functions instead of direct API calls

## AI Development Summary
- **Problem Discovery**: Used browser automation tools to test zoom functionality and identify non-working buttons
- **Root Cause Analysis**: Examined JavaScript code in unified template to find incorrect panzoom API usage
- **Solution Implementation**: 
  - Fixed zoom button HTML elements and JavaScript functions
  - Updated keyboard event handlers for consistency
- **Verification**: Regenerated demo files and tested both buttons and keyboard shortcuts
- **Tools Used**: Browser MCP for testing, file editing tools, Python script generation for demo updates

The fix ensures consistent zoom behavior across all interaction methods (mouse wheel, buttons, keyboard) and applies to all diagram types (Mermaid, PlantUML, Graphviz) using the unified template.